### PR TITLE
fix: add host in robots

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,5 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       disallow: '/private/',
     },
     sitemap: 'https://novin.fun/sitemaps/sitemap.xml',
+    host: 'https://novin.fun',
   };
 }


### PR DESCRIPTION
This pull request introduces a minor update to the `robots.ts` file, adding a `host` property to the robots metadata configuration. This change helps search engines correctly identify the primary domain for the site.

* Added `host: 'https://novin.fun'` to the robots metadata configuration in `src/app/robots.ts` to explicitly specify the site's primary domain.