### PR TITLE
fix: modify last mod with iso 8601

### DIFF
--- a/src/app/sitemaps/sitemap.ts
+++ b/src/app/sitemaps/sitemap.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { MetadataRoute } from 'next';
 import { DATA } from '@/data/resume';
+import { formatDateISO8601 } from '@/lib/utils';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const blogFolder = path.join(process.cwd(), 'content/');
@@ -13,7 +14,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       const slug = file.replace('.mdx', '');
       return {
         url: `https://novin.fun/blog/${slug}`,
-        lastModified: new Date().toISOString(),
+        lastModified: formatDateISO8601(new Date().toISOString()),
         changeFrequency: 'monthly' as const,
         priority: 0.8,
       };
@@ -21,7 +22,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const certificationList = DATA.certifications.map((certif) => ({
     url: `https://novin.fun/certification/${certif.slug}`,
-    lastModified: new Date(certif.start).toISOString(),
+    lastModified: formatDateISO8601(certif.start),
     changeFrequency: 'yearly' as const,
     priority: 0.9,
   }));
@@ -29,26 +30,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: 'https://novin.fun',
-      lastModified: new Date().toISOString(),
+      lastModified: formatDateISO8601(new Date().toISOString()),
       changeFrequency: 'daily' as const,
       priority: 1.0,
     },
     {
       url: 'https://novin.fun/certification',
-      lastModified: new Date().toISOString(),
+      lastModified: formatDateISO8601(new Date().toISOString()),
       changeFrequency: 'monthly' as const,
       priority: 0.9,
     },
     ...certificationList,
     {
       url: 'https://novin.fun/project',
-      lastModified: new Date().toISOString(),
+      lastModified: formatDateISO8601(new Date().toISOString()),
       changeFrequency: 'monthly' as const,
       priority: 0.9,
     },
     {
       url: 'https://novin.fun/blog',
-      lastModified: new Date().toISOString(),
+      lastModified: formatDateISO8601(new Date().toISOString()),
       changeFrequency: 'weekly' as const,
       priority: 0.8,
     },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -35,3 +35,7 @@ export function formatDate(date: string) {
     return `${fullDate} (${yearsAgo}y ago)`;
   }
 }
+
+export const formatDateISO8601 = (date: string) => {
+  return new Date(date).toISOString().split('T')[0];
+};


### PR DESCRIPTION
This pull request refactors how dates are formatted in the sitemap generation logic to ensure all `lastModified` fields use a consistent ISO 8601 date format (YYYY-MM-DD). The changes introduce a new utility function and update the relevant code to use it.

**Date formatting improvements:**

* Added a new utility function `formatDateISO8601` in `src/lib/utils.ts` to format dates as ISO 8601 strings (YYYY-MM-DD).
* Updated all instances of `lastModified` in `src/app/sitemaps/sitemap.ts` to use `formatDateISO8601` instead of `toISOString()`, ensuring consistent date formatting across sitemap entries.
* Imported the new `formatDateISO8601` function in `src/app/sitemaps/sitemap.ts`.